### PR TITLE
Change AB mag calculation to interpolate passband to spectrum resolution

### DIFF
--- a/castor_etc/spectrum.py
+++ b/castor_etc/spectrum.py
@@ -92,8 +92,7 @@ from scipy.integrate import simpson
 from scipy.interpolate import interp1d
 
 from . import constants as const
-from .conversions import (calc_photon_energy, flam_to_AB_mag, fnu_to_flam,
-                          mag_to_flux)
+from .conversions import calc_photon_energy, flam_to_AB_mag, fnu_to_flam, mag_to_flux
 from .filepaths import DATAPATH
 from .telescope import Telescope
 


### PR DESCRIPTION
This PR updates the AB magnitude calculation for a source's spectrum through a telescope's passbands.

Previously, we were interpolating the source spectrum to the passband's resolution. Instead, we should probably be interpolating the passband response curve to the source spectrum's resolution. There are two main reasons why I think we should do it this way.
1. In most cases, the spectrum is higher resolution than our passband, and
2. The curves in our passband files are relatively well-behaved compared to observational spectra, which may have lots of sharp peaks and troughs. If we interpolate the spectrum to the passband resolution, we risk losing these features that may have a substantial contribution to our SNR calculations. In contrast, since the passband throughputs are better behaved (i.e., smoother), any interpolation (even to a coarser spectrum) should capture the behaviour of the passband reasonably well.

If this rationale sounds right to you, @tewoods, and the changes to `spectrum.py` look alright, then you can approve these changes and I can merge this PR with the master branch.