### PR TITLE
Overhaul photometry calculations

### DIFF
--- a/castor_etc/conversions.py
+++ b/castor_etc/conversions.py
@@ -152,7 +152,7 @@ def convert_freq_wavelength(data, to="wavelength", output_unit=u.AA):
     elif to == "frequency":
         unit = u.AA  # data are wavelengths
     else:
-        raise ValueError(f"to must be 'wavelength' or 'frequency'")
+        raise ValueError("to must be 'wavelength' or 'frequency'")
     #
     if isinstance(data, u.Quantity):
         data = data.to(unit)
@@ -348,7 +348,7 @@ def convert_rel_abs_mag(mag, dist, mag_err=0.0, dist_err=0.0, to="abs"):
         new_mag = mag + 5 * (np.log10(dist) - 1)
     else:
         raise ValueError("to must be either 'abs' or 'rel'")
-    new_mag_err = np.sqrt(mag_err ** 2 + (5 / np.log(10) * dist_err / dist) ** 2)
+    new_mag_err = np.sqrt(mag_err**2 + (5 / np.log(10) * dist_err / dist) ** 2)
     #
     return new_mag, new_mag_err
 

--- a/castor_etc/photometry.py
+++ b/castor_etc/photometry.py
@@ -1588,7 +1588,6 @@ class Photometry:
                 "INFO: The `reddening` parameter is ignored for `CustomSource` objects. "
                 + "You can silence this message by setting `quiet=True`."
             )
-            include_redleak = False
         #
         # Make some useful variables
         #


### PR DESCRIPTION
This is a big update. This PR changes how we do photometry calculations in the backend. There is a [Jupyter notebook](https://github.com/CASTOR-telescope/ETC_notebooks/blob/4f6bbb10c62e30a312ebe0e129990b1c778d8c46/photometry_update.ipynb) in the [ETC_notebooks](https://github.com/CASTOR-telescope/ETC_notebooks) repository with examples and more details as to what this PR attempts to accomplish.

In brief, we calculate the fraction of flux enclosed within the user's aperture to do our SNR calculations. We accomplish this by comparing the flux within the user's aperture to a reference aperture. We supersample all apertures to make our estimates more accurate, then we bin them down to the proper resolution.

This approach has the added bonus of adding detail to unresolved sources. Previously, we were simply using the flux at the centre of the pixel as the flux for the whole pixel. One problem with this is that galaxies that had a high Sersic index were treated as just 1 bright pixel in a sea of black. Now, we supersample the aperture before binning the arrays down to the right resolution, meaning we are using many smaller pixels to determine the flux through each final pixel. I use an `n=4` galaxy in the linked notebook to illustrate the changes. 