### PR TITLE
Add parameter to control PSF normalization

### DIFF
--- a/castor_etc/telescope.py
+++ b/castor_etc/telescope.py
@@ -677,7 +677,7 @@ class Telescope:
 
         psfs = dict.fromkeys(passbands)
         for band in passbands:
-            psfs[band] = fits.getdata(psf_filepaths[band])
+            psfs[band] = fits.getdata(psf_filepaths[band]).T  # transpose to match x/y
         self.psfs = psfs
         self.psf_supersample_factor = psf_supersample_factor
 
@@ -778,7 +778,7 @@ class Telescope:
                 extent=[-extent_x, extent_x, -extent_y, extent_y],
                 cmap=_ds9heat_cmap,
                 norm=norm,
-            )  # no need to transpose PSF. Same result as visualizing with DS9
+            )  # no need to transpose PSF because already transposed when loading data
             ax.tick_params(color="w", which="both")
             cbar = fig.colorbar(img)
             cbar.set_label("Fraction of Flux Contained Within Pixel")

--- a/castor_etc/telescope.py
+++ b/castor_etc/telescope.py
@@ -724,16 +724,21 @@ class Telescope:
         """
         return deepcopy(self)
 
-    def show_psf(self, passband, plot=True):
+    def show_psf(self, passband, norm=None, plot=True):
         """
         Visualize the point spread function (PSF) of a given passband. The visualization
         assumes (0, 0) is at the center of the image (this assumption does not affect
-        calculations, and is purely for visualization purposes).
+        calculations, and is purely for visualization purposes). Non-finite values will be
+        shown as black pixels in the plot.
 
         Parameters
         ----------
           passband :: str
             The passband corresponding to the PSF.
+
+          norm :: `matplotlib.colors.Normalize` object or None
+            The normalization to use for the PSF plot. If None, use the default (linear)
+            scaling.
 
           plot :: bool
             If True, plot the PSF and return None. If False, return the figure, axis,
@@ -763,6 +768,7 @@ class Telescope:
         extent_x = 0.5 * psf_px_scale * psf.shape[1]
         #
         rc = {"axes.grid": False}
+        _ds9heat_cmap.set_bad("k")  # set NaNs and infs to black
         with plt.rc_context(rc):  # matplotlib v3.5.x has bug affecting grid + imshow
             fig, ax = plt.subplots()
             img = ax.imshow(
@@ -771,6 +777,7 @@ class Telescope:
                 interpolation=None,
                 extent=[-extent_x, extent_x, -extent_y, extent_y],
                 cmap=_ds9heat_cmap,
+                norm=norm,
             )  # no need to transpose PSF. Same result as visualizing with DS9
             ax.tick_params(color="w", which="both")
             cbar = fig.colorbar(img)


### PR DESCRIPTION
This PR just adds the ability for the user to control how the PSF is displayed in the plot. The default is still a linear colour bar, but the user can change the colour scale to be, e.g., logarithmic.

I'll wait for all other changes from https://github.com/CASTOR-telescope/ETC/pull/12 to be merged before I merge this PR.