### PR TITLE
Update parameters.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 See [semantic versioning](https://semver.org/spec/v2.0.0.html) for the rationale behind
 the version numbers.
 
+## Current Version
+
+- Change `MP` and `READ_NOISE` parameters in parameters.py to 930 and 3.0, respectively.
+  Also add some comments about parameters
+  ([#22](https://github.com/CASTOR-telescope/ETC/pull/22))
+
 ## [1.2.1](https://github.com/CASTOR-telescope/ETC/tree/v1.2.1) (2023-09-18)
 
 - Add ability to control the colour bar normalization when visualizing PSFs

--- a/castor_etc/parameters.py
+++ b/castor_etc/parameters.py
@@ -118,7 +118,7 @@ IFOV_DIMEN = [0.44, 0.56] << u.deg  # degrees. Angular dimensions
 IFOV_AREA = IFOV_DIMEN[0] * IFOV_DIMEN[1]  # degrees^2
 
 # Number of pixels in CCD (x 1 million)
-MP = 960  # megapixels
+MP = 930  # megapixels
 
 # Aperture diameter
 MIRROR_DIAMETER = 100 << u.cm  # cm
@@ -131,10 +131,12 @@ MIRROR_AREA = pi * (0.5 * MIRROR_DIAMETER) * (0.5 * MIRROR_DIAMETER)  # cm^2
 # CASTOR operates at 180 K, implying:
 # dark current = 0.5^((223.15K - 180K) / 6) * 0.01 ~ 1e-4 electrons/s/pixel (negligible)
 DARK_CURRENT = 1e-4  # electrons/s/pixel
+# Dark current will increase linearly over time to 0.01 electrons/s/pixel by the end of 5
+# years
 
 BIAS = 100  # electron
 
-READ_NOISE = 2.0  # electron/pixel (high-gain). Read noise is 30 electrons for low-gain
+READ_NOISE = 3.0  # electron/pixel (high-gain). Read noise is 30 electrons for low-gain
 
 GAIN = 2.0  # electron/ADU
 

--- a/castor_etc/telescope.py
+++ b/castor_etc/telescope.py
@@ -201,7 +201,7 @@ class Telescope:
         px_scale=params.PX_SCALE,
         ifov_dimen=params.IFOV_DIMEN,  # not currently used for any calculations
         mp=params.MP,  # not currently used for any calculations
-        mirror_diameter=params.MIRROR_DIAMETER,
+        mirror_diameter=params.MIRROR_DIAMETER,  # not currently used for any calculations
         dark_current=params.DARK_CURRENT,
         bias=params.BIAS,  # not currently used for any calculations
         read_noise=params.READ_NOISE,


### PR DESCRIPTION
Fixes the typo in #21, updates read noise to 3.0 electron/pixel, and adds a few comments about parameters.