### PR TITLE
[FEATURE]: add notebooks repo as a git submodule

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve the CASTOR ETC!
+title: "[BUG]: <Enter a brief description>"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+To the best of your abilities, describe what bug you encountered.
+
+Please provide the following details:
+ - OS: [e.g. Windows 11, MacOS, Linux (please provide distro if possible)]
+ - Python version (`python -V` in terminal) :
+ - `castor_etc` version: 
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an enhancement or feature for this project
+title: "[FEAT]: <Enter a brief description>"
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the feature you'd like to see in CASTOR ETC**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ETC_notebooks"]
+	path = ETC_notebooks
+	url = git@github.com:CASTOR-telescope/ETC_notebooks.git

--- a/castor_etc/__init__.py
+++ b/castor_etc/__init__.py
@@ -1,3 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 CASTOR Exposure Time Calculator (ETC)
 =====================================
@@ -14,68 +74,6 @@ Includes:
 
 Author: Isaac Cheng
 Contact: isaac.cheng.ca@gmail.com
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 __all__ = [

--- a/castor_etc/background.py
+++ b/castor_etc/background.py
@@ -1,68 +1,69 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Utilities to characterize the sky background (Earthshine, zodiacal light, geocoronal
-emission).
+Background Tools
+================
 
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+`castor_etc.background` provides utilities to characterize the sky background (Earthshine, zodiacal light, geocoronal
+emission) through the `Background` class.
 """
 
 import warnings

--- a/castor_etc/constants.py
+++ b/castor_etc/constants.py
@@ -1,67 +1,70 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Useful constants. (N.B. use cgs units when possible)
+Constants
+==========
 
----
+This provides useful* constants. (N.B. use cgs units when possible).
 
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+*'Useful' relative to whatever the FORECASTOR team deems as useful.
 """
 
 import astropy.units as u

--- a/castor_etc/conversions.py
+++ b/castor_etc/conversions.py
@@ -1,5 +1,68 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Utilities to convert between different units and quantities.
+Unit conversion utilities
+=========================
+
+`castor_etc.conversions` provides utility methods to convert between different units and quantities.
 
 Common units (also see <https://pysynphot.readthedocs.io/en/latest/units.html>):
   - fnu :: erg/s/cm^2/Hz
@@ -7,67 +70,6 @@ Common units (also see <https://pysynphot.readthedocs.io/en/latest/units.html>):
   - photnu :: photons/s/cm^2/Hz
   - photlam :: photons/s/cm^2/A
 
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 import astropy.units as u

--- a/castor_etc/data/UVMOS_data/__init__.py
+++ b/castor_etc/data/UVMOS_data/__init__.py
@@ -1,65 +1,64 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Data files for CASTOR UVMOS.
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+UVMOS data files
+================
 """

--- a/castor_etc/data/__init__.py
+++ b/castor_etc/data/__init__.py
@@ -1,73 +1,73 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Data Files for CASTOR
-=====================
+Data Utilities
+==============
+
+Data files for defining CASTOR parameters
 
 Includes:
   - Background noise estimates
   - Passband response curves
   - Spectral energy distributions
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 __all__ = [

--- a/castor_etc/data/galaxy_spectra/__init__.py
+++ b/castor_etc/data/galaxy_spectra/__init__.py
@@ -1,65 +1,64 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 Galaxy spectra.
 
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """

--- a/castor_etc/data/grism_data/__init__.py
+++ b/castor_etc/data/grism_data/__init__.py
@@ -1,6 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 Grism dispersion, profile and efficiency files.
-
----
-
 """

--- a/castor_etc/data/passbands/__init__.py
+++ b/castor_etc/data/passbands/__init__.py
@@ -1,65 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 Passband response curve definition files.
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """

--- a/castor_etc/data/pickles_spectra/__init__.py
+++ b/castor_etc/data/pickles_spectra/__init__.py
@@ -1,65 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 Pickles spectra files.
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """

--- a/castor_etc/data/psfs/__init__.py
+++ b/castor_etc/data/psfs/__init__.py
@@ -1,65 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 CASTOR point spread functions (PSFs).
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """

--- a/castor_etc/data/sky_background/__init__.py
+++ b/castor_etc/data/sky_background/__init__.py
@@ -1,70 +1,69 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 Background Noise Data for CASTOR
+================================
 
 Includes:
   - Earthshine
   - Zodiacal light
   - Geocoronal emission (aka "airglow")
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """

--- a/castor_etc/data/sky_background/background_values.py
+++ b/castor_etc/data/sky_background/background_values.py
@@ -1,67 +1,65 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 Contains average sky background values and geocoronal emission line data.
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 import astropy.units as u

--- a/castor_etc/filepaths.py
+++ b/castor_etc/filepaths.py
@@ -1,67 +1,65 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Contains filepaths for CASTOR.
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+Contains filepaths for CASTOR. Mostly private constants that should be re-factored elsewhere later.
 """
 
 from os.path import dirname, abspath, join

--- a/castor_etc/grism.py
+++ b/castor_etc/grism.py
@@ -1,67 +1,71 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Grism calculations.
+Grism tool
+==========
 
----
+Classes and methods for grism calculations.
 
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+.. caution:: 
+    There is another `existing grism tool <https://github.com/gnoir0t/ETC_grism>`_ for the CASTOR grism. Please refer to that for the latest updates.
 """
 
 import warnings

--- a/castor_etc/parameters.py
+++ b/castor_etc/parameters.py
@@ -1,67 +1,69 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Contains parameters for CASTOR imaging chain.
+Parameters
+==========
 
----
+`castor_etc.parameters` contains predefined constatns for the CASTOR imaging chain.
 
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 from math import pi

--- a/castor_etc/photometry.py
+++ b/castor_etc/photometry.py
@@ -1,67 +1,68 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Utilities for photometric calculations.
+Photometry
+==========
 
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+`castor_etc.photometry` provides classes for photometric calculations.
 """
 
 import warnings

--- a/castor_etc/sources.py
+++ b/castor_etc/sources.py
@@ -1,7 +1,70 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Simulates different astronomical sources and contains different flux profiles. Also
-supports arbitrary surface brightness profiles (either from a function or from a FITS
-file).
+Sources
+=======
+
+`castor_etc.sources` provides methods and classes to define and simulate different astronomical sources
+with arbitrary flux profiles. Also supports arbitrary surface brightness profiles (either from a function or from a FITS
+file). This subpackage mainly consists of the `Profile` class and the `Source` class.
 
 Predefined flux profiles:
   - uniform
@@ -13,68 +76,6 @@ Predefined source types:
   - point (e.g., for stars)
   - extended (e.g., for supernova remnants)
   - galaxies
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 from abc import ABCMeta, abstractmethod

--- a/castor_etc/spectrum.py
+++ b/castor_etc/spectrum.py
@@ -1,5 +1,68 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Generate and handle spectral data and normalizations.
+Spectrum Utilities
+==================
+
+`castor_etc.spectrum` provides methods to handle spectral data and normalizations.
 
 Includes:
   - redshifting wavelengths
@@ -16,68 +79,6 @@ Includes:
     - normalize a spectrum to a given bolometric luminosity and distance
     - calculate the average value of a spectrum (erg/s/cm^2/A or AB mag) either within a
       passband or over the whole spectrum
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 import os

--- a/castor_etc/telescope.py
+++ b/castor_etc/telescope.py
@@ -1,67 +1,69 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Utilities to characterize the telescope parameters.
+Telescope Utilities
+===================
 
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+The `castor_etc.telescope` package provides methods and classes to simulate and
+characterize telescope parameters.
 """
 
 import warnings
@@ -788,8 +790,9 @@ class Telescope:
         """
         try:
             psf = self.psfs[passband]
-        except KeyError:
-            raise KeyError(f"{passband} is not a valid passband")
+        except KeyError as exc:
+            raise KeyError(f"{passband} is not a valid passband") from exc
+        
         psf_px_scale = (self.px_scale / self.psf_supersample_factor).to(u.arcsec).value
         extent_y = 0.5 * psf_px_scale * psf.shape[0]
         extent_x = 0.5 * psf_px_scale * psf.shape[1]

--- a/castor_etc/tests/__init__.py
+++ b/castor_etc/tests/__init__.py
@@ -1,67 +1,65 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 Unit tests for the castor_etc module.
 
 TODO: these tests are severely outdated & no longer reflect the current ETC functionality
-
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """

--- a/castor_etc/tests/test_conversions.py
+++ b/castor_etc/tests/test_conversions.py
@@ -1,3 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 test_conversions.py
 

--- a/castor_etc/tests/test_energy.py
+++ b/castor_etc/tests/test_energy.py
@@ -1,3 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 test_energy.py
 

--- a/castor_etc/tests/test_spectrum.py
+++ b/castor_etc/tests/test_spectrum.py
@@ -1,3 +1,63 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
 test_conversions.py
 

--- a/castor_etc/transit.py
+++ b/castor_etc/transit.py
@@ -1,67 +1,69 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-Transit calculations.
+Transit Calulations
+===================
 
----
-
-        GNU General Public License v3 (GNU GPLv3)
-
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+The `castor_etc.transit` package provides methods and classes to simulate
+a transit event such as observations.
 """
 
 import warnings

--- a/castor_etc/uvmos_spectroscopy.py
+++ b/castor_etc/uvmos_spectroscopy.py
@@ -1,67 +1,74 @@
+#         GNU General Public License v3 (GNU GPLv3)
+#
+# (c) 2022.                            (c) 2022.
+# Government of Canada                 Gouvernement du Canada
+# National Research Council            Conseil national de recherches
+# Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+# All rights reserved                  Tous droits réservés
+#
+# NRC disclaims any warranties,        Le CNRC dénie toute garantie
+# expressed, implied, or               énoncée, implicite ou légale,
+# statutory, of any kind with          de quelque nature que ce
+# respect to the software,             soit, concernant le logiciel,
+# including without limitation         y compris sans restriction
+# any warranty of merchantability      toute garantie de valeur
+# or fitness for a particular          marchande ou de pertinence
+# purpose. NRC shall not be            pour un usage particulier.
+# liable in any event for any          Le CNRC ne pourra en aucun cas
+# damages, whether direct or           être tenu responsable de tout
+# indirect, special or general,        dommage, direct ou indirect,
+# consequential or incidental,         particulier ou général,
+# arising from the use of the          accessoire ou fortuit, résultant
+# software. Neither the name           de l'utilisation du logiciel. Ni
+# of the National Research             le nom du Conseil National de
+# Council of Canada nor the            Recherches du Canada ni les noms
+# names of its contributors may        de ses  participants ne peuvent
+# be used to endorse or promote        être utilisés pour approuver ou
+# products derived from this           promouvoir les produits dérivés
+# software without specific prior      de ce logiciel sans autorisation
+# written permission.                  préalable et particulière
+#                                      par écrit.
+#
+# This file is part of the             Ce fichier fait partie du projet
+# FORECASTOR ETC project.              FORECASTOR ETC.
+#
+# FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
+# you can redistribute it and/or       libre ; vous pouvez le redistribuer
+# modify it under the terms of         ou le modifier suivant les termes de
+# the GNU General Public               la "GNU General Public
+# License as published by the          License" telle que publiée
+# Free Software Foundation,            par la Free Software Foundation :
+# either version 3 of the              soit la version 3 de cette
+# License, or (at your option)         licence, soit (à votre gré)
+# any later version.                   toute version ultérieure.
+#
+# FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
+# in the hope that it will be          dans l'espoir qu'il vous
+# useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
+# without even the implied warranty    GARANTIE : sans même la garantie
+# of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
+# A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
+# GNU General Public License for       PARTICULIER. Consultez la Licence
+# more details.                        Générale Publique GNU pour plus
+#                                      de détails.
+#
+# You should have received             Vous devriez avoir reçu une
+# a copy of the GNU General            copie de la Licence Générale
+# Public License along with            Publique GNU avec FORECASTOR ETC ;
+# FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
+# <http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
+
 """
-UVMOS Spectroscopy calculations.
+UVMOS Spectroscopy
+===================
 
----
+`castor_etc.uvmos_spectroscopy` package simulates the effects of the currently
+proposed design for the UVMOS instrument.
 
-        GNU General Public License v3 (GNU GPLv3)
+.. caution::
+    The UVMOS design is currently undergoing active study so this code will likely
+    undergo drastic changes frequently for the foreseeable future.
 
-(c) 2022.                            (c) 2022.
-Government of Canada                 Gouvernement du Canada
-National Research Council            Conseil national de recherches
-Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-All rights reserved                  Tous droits réservés
-
-NRC disclaims any warranties,        Le CNRC dénie toute garantie
-expressed, implied, or               énoncée, implicite ou légale,
-statutory, of any kind with          de quelque nature que ce
-respect to the software,             soit, concernant le logiciel,
-including without limitation         y compris sans restriction
-any warranty of merchantability      toute garantie de valeur
-or fitness for a particular          marchande ou de pertinence
-purpose. NRC shall not be            pour un usage particulier.
-liable in any event for any          Le CNRC ne pourra en aucun cas
-damages, whether direct or           être tenu responsable de tout
-indirect, special or general,        dommage, direct ou indirect,
-consequential or incidental,         particulier ou général,
-arising from the use of the          accessoire ou fortuit, résultant
-software. Neither the name           de l'utilisation du logiciel. Ni
-of the National Research             le nom du Conseil National de
-Council of Canada nor the            Recherches du Canada ni les noms
-names of its contributors may        de ses  participants ne peuvent
-be used to endorse or promote        être utilisés pour approuver ou
-products derived from this           promouvoir les produits dérivés
-software without specific prior      de ce logiciel sans autorisation
-written permission.                  préalable et particulière
-                                     par écrit.
-
-This file is part of the             Ce fichier fait partie du projet
-FORECASTOR ETC project.              FORECASTOR ETC.
-
-FORECASTOR ETC is free software:     FORECASTOR ETC est un logiciel
-you can redistribute it and/or       libre ; vous pouvez le redistribuer
-modify it under the terms of         ou le modifier suivant les termes de
-the GNU General Public               la "GNU General Public
-License as published by the          License" telle que publiée
-Free Software Foundation,            par la Free Software Foundation :
-either version 3 of the              soit la version 3 de cette
-License, or (at your option)         licence, soit (à votre gré)
-any later version.                   toute version ultérieure.
-
-FORECASTOR ETC is distributed        FORECASTOR ETC est distribué
-in the hope that it will be          dans l'espoir qu'il vous
-useful, but WITHOUT ANY WARRANTY;    sera utile, mais SANS AUCUNE
-without even the implied warranty    GARANTIE : sans même la garantie
-of MERCHANTABILITY or FITNESS FOR    implicite de COMMERCIALISABILITÉ
-A PARTICULAR PURPOSE. See the        ni d'ADÉQUATION À UN OBJECTIF
-GNU General Public License for       PARTICULIER. Consultez la Licence
-more details.                        Générale Publique GNU pour plus
-                                     de détails.
-
-You should have received             Vous devriez avoir reçu une
-a copy of the GNU General            copie de la Licence Générale
-Public License along with            Publique GNU avec FORECASTOR ETC ;
-FORECASTOR ETC. If not, see          si ce n'est pas le cas, consultez :
-<http://www.gnu.org/licenses/>.      <http://www.gnu.org/licenses/>.
 """
 
 import astropy.units as u


### PR DESCRIPTION
Another minor QoL change akin to #39. This change simply adds our current ETC_notebooks repo as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules), which is git's way of managing projects with dependencies.

The actual folder itself can be renamed if needed be. This will be closed after #38 and #39 are merged in to prevent possible conflicts.