### PR TITLE
fix: correct error message 'avg' typo in add_geocoronal_emission

### DIFF
--- a/castor_etc/background.py
+++ b/castor_etc/background.py
@@ -249,7 +249,7 @@ class Background:
             flux = GEOCORONAL_FLUX_LOW
         elif not isinstance(flux, Number):
             raise ValueError(
-                "`flux` must be a scalar or one of 'high', 'medium', or 'low'"
+                "`flux` must be a scalar or one of 'high', 'avg', or 'low'"
             )
         if isinstance(wavelength, u.Quantity):
             try:


### PR DESCRIPTION
Fix ValueError message to use 'avg' instead of 'medium' to match actual valid input values ('high', 'avg', 'low') in background.py. Closes CASTOR-telescope/ETC#63